### PR TITLE
feat: Add custom badge plugin and integrate with markdown configuration

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -2,6 +2,7 @@ import { defineConfig } from "vitepress";
 import companiesMap from "./sitemap/companies.mjs";
 import notesMap from "./sitemap/notes.mjs";
 import rewrites from "./sitemap/rewrites.mjs";
+import { applyMarkdownPlugins } from "./plugins";
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
   title: "Interview BD",
@@ -59,4 +60,7 @@ export default defineConfig({
       ],
     ],
   },
+  markdown: {
+    config: applyMarkdownPlugins
+  }
 });

--- a/docs/.vitepress/plugins/customBadge.js
+++ b/docs/.vitepress/plugins/customBadge.js
@@ -1,0 +1,51 @@
+// plugins/customBadge.js
+export function customBadgePlugin(md) {
+    md.inline.ruler.after('emphasis', 'custom-badge', (state, silent) => {
+      const start = state.pos;
+      
+      // Check for @@
+      if (state.src.slice(start, start + 2) !== '@@') {
+        return false;
+      }
+      
+      // Find the closing @@
+      const endMarker = state.src.indexOf('@@', start + 2);
+      if (endMarker === -1) {
+        return false;
+      }
+      
+      // Don't proceed if just checking for existence
+      if (silent) {
+        return true;
+      }
+      
+      // Extract the content between @@ markers
+      const content = state.src.slice(start + 2, endMarker);
+      
+      // Check if there's a type specified (format: @@type:text@@)
+      let badgeType = 'warning'; // Default type
+      let badgeText = content.trim();
+      
+      // If there's a colon, parse for type and text
+      const colonPos = content.indexOf(':');
+      if (colonPos !== -1) {
+        const possibleType = content.slice(0, colonPos).trim().toLowerCase();
+        // Valid badge types in VitePress
+        const validTypes = ['info', 'tip', 'warning', 'danger'];
+        
+        if (validTypes.includes(possibleType)) {
+          badgeType = possibleType;
+          badgeText = content.slice(colonPos + 1).trim();
+        }
+      }
+      
+      // Create token for the Badge component
+      const token = state.push('html_inline', '', 0);
+      token.content = `<Badge type="${badgeType}" text="${badgeText}" />`;
+      
+      // Update position
+      state.pos = endMarker + 2;
+      
+      return true;
+    });
+  }

--- a/docs/.vitepress/plugins/index.js
+++ b/docs/.vitepress/plugins/index.js
@@ -1,0 +1,15 @@
+// plugins/index.js
+import { customBadgePlugin } from './customBadge'
+
+// Export all plugins
+export {
+  customBadgePlugin
+}
+
+// Helper function to apply all plugins at once
+export function applyMarkdownPlugins(md) {
+  customBadgePlugin(md)
+  // Add other plugins here as you create them
+  // examplePlugin(md)
+  // anotherPlugin(md)
+}


### PR DESCRIPTION
This PR adds a custom markdown syntax for badge by extending `markdown-it` parser

## Usage
```
@@badge@@
@@warning:badge@@
@@tip:badge@@
@@info:badge@@
```
This is parsed to convert to vitepress badge syntax `<Badge style="" text="" />